### PR TITLE
Fix getting current operation mode for water heater

### DIFF
--- a/custom_components/wundasmart/strings.json
+++ b/custom_components/wundasmart/strings.json
@@ -47,10 +47,8 @@
     "water_heater": {
       "wundasmart": {
         "state": {
-          "auto_on": "On (Auto)",
-          "auto_off": "Off (Auto)",
-          "boost_on": "On",
-          "boost_off": "Off",
+          "on": "On",
+          "off": "Off",
           "auto": "Auto",
           "boost_30": "Boost (30 mins)",
           "boost_60": "Boost (1 hour)",

--- a/custom_components/wundasmart/translations/en.json
+++ b/custom_components/wundasmart/translations/en.json
@@ -47,10 +47,8 @@
         "water_heater": {
             "wundasmart": {
                 "state": {
-                    "auto_on": "On (Auto)",
-                    "auto_off": "Off (Auto)",
-                    "boost_on": "On",
-                    "boost_off": "Off",
+                    "on": "On",
+                    "off": "Off",
                     "auto": "Auto",
                     "boost_30": "Boost (30 mins)",
                     "boost_60": "Boost (1 hour)",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,6 @@
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.common import load_fixture
 from custom_components.wundasmart.const import DOMAIN
-from custom_components.wundasmart.water_heater import STATE_AUTO_ON, STATE_AUTO_OFF, STATE_BOOST_ON
 from unittest.mock import patch
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import HomeAssistant

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -1,7 +1,7 @@
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.common import load_fixture
 from custom_components.wundasmart.const import DOMAIN
-from custom_components.wundasmart.water_heater import STATE_AUTO_ON, STATE_AUTO_OFF, STATE_BOOST_ON
+from custom_components.wundasmart.water_heater import STATE_ON, STATE_OFF
 from unittest.mock import patch
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import HomeAssistant
@@ -23,7 +23,7 @@ async def test_water_header(hass: HomeAssistant, config):
         state = hass.states.get("water_heater.smart_hubswitch")
 
         assert state
-        assert state.state == STATE_AUTO_ON
+        assert state.state == STATE_ON
 
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert coordinator
@@ -36,7 +36,7 @@ async def test_water_header(hass: HomeAssistant, config):
         state = hass.states.get("water_heater.smart_hubswitch")
 
         assert state
-        assert state.state == STATE_BOOST_ON
+        assert state.state == STATE_ON
 
     data = deserialize_get_devices_fixture(load_fixture("test_get_devices3.json"))
     with patch("custom_components.wundasmart.get_devices", return_value=data):
@@ -46,7 +46,7 @@ async def test_water_header(hass: HomeAssistant, config):
         state = hass.states.get("water_heater.smart_hubswitch")
 
         assert state
-        assert state.state == STATE_AUTO_OFF
+        assert state.state == STATE_OFF
 
 
 async def test_water_header_set_operation(hass: HomeAssistant, config):


### PR DESCRIPTION
State and operation_mode are the same thing for the WaterHeaterEntity, and the current operation mode (which self.state returns) has to be an operation mode that can also be selected.

When a manual override has been set try to determine the most sensible operation mode to display. Otherwise, use on/off and add those to the list of operation modes allowed. Since we can't turn the water heater on or off without a duration, alias on/off to the longest preconfigured boost/off modes.

Fixes #27