### PR TITLE
Add sensors and service call for getting and setting presets (#36)

### DIFF
--- a/custom_components/wundasmart/const.py
+++ b/custom_components/wundasmart/const.py
@@ -1,5 +1,9 @@
 """Constants for the wundasmart integration."""
 from dataclasses import dataclass
+from homeassistant.components.climate import (
+    PRESET_ECO,
+    PRESET_COMFORT
+)
 
 DOMAIN = "wundasmart"
 
@@ -9,7 +13,6 @@ CONF_READ_TIMEOUT = "read_timeout"
 DEFAULT_SCAN_INTERVAL = 300
 DEFAULT_CONNECT_TIMEOUT = 5
 DEFAULT_READ_TIMEOUT = 5
-
 
 @dataclass
 class DeviceIdRanges:

--- a/custom_components/wundasmart/services.yaml
+++ b/custom_components/wundasmart/services.yaml
@@ -32,3 +32,32 @@ hw_off:
       default: '00:30:00'
       selector:
         time:
+set_preset_temperature:
+  name: Set Preset Temperature
+  description: Sets one of the temperature presets.
+  target:
+    entity:
+      integration: wundasmart
+      domain: climate
+  fields:
+    preset:
+      name: Preset
+      description: Named preset to set temperature of.
+      required: true
+      selector:
+          select:
+            translation_key: "preset"
+            options:
+              - label: "Reduced"
+                value: "reduced"
+              - label: "Eco"
+                value: "eco"
+              - label: "Comfort"
+                value: "comfort"
+    temperature:
+      name: "Temperature"
+      description: "Temperature to set for the preset."
+      required: true
+      selector:
+        number:
+          min: 0

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -50,20 +50,11 @@ async def test_set_temperature(hass: HomeAssistant, config):
     entry.add_to_hass(hass)
 
     # Test setting temperature works
-    data = deserialize_get_devices_fixture(load_fixture("test_get_devices3.json"))
-    tdata = deserialize_get_devices_fixture(load_fixture("test_set_temperature.json"))
-    with patch("custom_components.wundasmart.get_devices", side_effect=[data, tdata]), \
+    data = deserialize_get_devices_fixture(load_fixture("test_set_temperature.json"))
+    with patch("custom_components.wundasmart.get_devices", return_value=data), \
             patch("custom_components.wundasmart.climate.send_command", return_value=None) as mock:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-
-        # Check the state before setting the temperature
-        state = hass.states.get("climate.test_room")
-        assert state
-        assert state.attributes["current_temperature"] == 16.0
-        assert state.attributes["temperature"] == 20
-        assert state.state == "auto"
-        assert state.attributes["hvac_action"] == HVACAction.OFF
 
         # set the temperature
         await hass.services.async_call("climate", "set_temperature", {
@@ -174,6 +165,30 @@ async def test_set_presets(hass: HomeAssistant, config):
         assert mock.call_args.kwargs["params"]["roomid"] == 121
         assert mock.call_args.kwargs["params"]["temp"] == 21.0
 
+
+async def test_set_preset_temps(hass: HomeAssistant, config):
+    entry = MockConfigEntry(domain=DOMAIN, data=config)
+    entry.add_to_hass(hass)
+
+    data = deserialize_get_devices_fixture(load_fixture("test_set_presets.json"))
+    with patch("custom_components.wundasmart.get_devices", return_value=data), \
+            patch("custom_components.wundasmart.climate.send_command", return_value=None) as mock:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        with patch("custom_components.wundasmart.climate.set_register", return_value=None) as mock:
+            await hass.services.async_call("wundasmart", "set_preset_temperature", {
+                "entity_id": "climate.test_room",
+                "preset": "eco",
+                "temperature": 10
+            })
+            await hass.async_block_till_done()
+
+            # Check send_command was called correctly
+            assert mock.call_count == 1
+            assert mock.call_args.kwargs["device_id"] == 121
+            assert mock.call_args.kwargs["register_id"] == "t_norm"
+            assert mock.call_args.kwargs["value"] == 10
 
 async def test_turn_on_off(hass: HomeAssistant, config):
     entry = MockConfigEntry(domain=DOMAIN, data=config)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -41,6 +41,18 @@ async def test_sensors(hass: HomeAssistant, config):
         assert ext_temp_state
         assert ext_temp_state.state == "18.0"
 
+        t_lo_state = hass.states.get("sensor.test_room_reduced_preset")
+        assert t_lo_state
+        assert t_lo_state.state == "14.00"
+
+        t_norm_state = hass.states.get("sensor.test_room_eco_preset")
+        assert t_norm_state
+        assert t_norm_state.state == "19.00"
+
+        t_hi_state = hass.states.get("sensor.test_room_comfort_preset")
+        assert t_hi_state
+        assert t_hi_state.state == "21.00"
+
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     assert coordinator
 


### PR DESCRIPTION
* Add sensors for room preset temperatures

* Add service for setting preset temps

* Avoid using side_effect with patch in tests

  Changes can make get_devices be called multiple times, breaking tests that rely on it being called an exact number of times.

Fixes #35