### PR TITLE
Separate Room Devices

### DIFF
--- a/custom_components/wundasmart/__init__.py
+++ b/custom_components/wundasmart/__init__.py
@@ -160,6 +160,7 @@ class WundasmartDataUpdateCoordinator(DataUpdateCoordinator):
 
     @property
     def device_info(self) -> DeviceInfo | None:
+        """Return device info for the hub device."""
         if self._device_sn is None:
             return None
 
@@ -167,6 +168,22 @@ class WundasmartDataUpdateCoordinator(DataUpdateCoordinator):
             identifiers={(DOMAIN, self._device_sn)},
             manufacturer="Wunda",
             name=self._device_name or "Smart HubSwitch",
+            model="WundaSmart Hub",
             hw_version=self._hw_version,
             sw_version=self._sw_version
+        )
+
+    def get_room_device_info(self, room_id: str, room_device: dict) -> DeviceInfo | None:
+        """Return device info for a room/zone."""
+        if self._device_sn is None:
+            return None
+
+        room_name = room_device.get("name", f"Room {room_id}")
+        
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._device_sn}_room_{room_id}")},
+            manufacturer="Wunda",
+            name=room_name,
+            model="WundaSmart Room",
+            via_device=(DOMAIN, self._device_sn),
         )

--- a/custom_components/wundasmart/__init__.py
+++ b/custom_components/wundasmart/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_SC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry
 
 from .const import *
 from .session import get_persistent_session
@@ -64,12 +65,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
-
-
 async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Update listener."""
     # Check if we're switching from separate devices to legacy mode
@@ -84,25 +79,23 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
 
 async def _cleanup_room_devices(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Remove room devices when switching to legacy mode."""
-    from homeassistant.helpers import device_registry as dr
-    
-    device_registry = dr.async_get(hass)
+    _device_registry = device_registry.async_get(hass)
     
     # Find all room devices for this integration
-    devices = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
+    devices = device_registry.async_entries_for_config_entry(_device_registry, config_entry.entry_id)
     
     removed_count = 0
     for device in devices:
         # Check if this is a room device (not the main hub)
         for identifier in device.identifiers:
             if identifier[0] == DOMAIN and "_room_" in str(identifier[1]):
-                _LOGGER.info(f"Removing orphaned room device: {device.name} ({identifier[1]})")
-                device_registry.async_remove_device(device.id)
+                _LOGGER.debug(f"Removing orphaned room device: {device.name} ({identifier[1]})")
+                _device_registry.async_remove_device(device.id)
                 removed_count += 1
                 break
     
     if removed_count > 0:
-        _LOGGER.info(f"Removed {removed_count} orphaned room device(s) when switching to legacy mode")
+        _LOGGER.debug(f"Removed {removed_count} orphaned room device(s) when switching to single device mode")
 
 
 class WundasmartDataUpdateCoordinator(DataUpdateCoordinator):
@@ -115,7 +108,7 @@ class WundasmartDataUpdateCoordinator(DataUpdateCoordinator):
                  wunda_pass: str,
                  update_interval: int,
                  timeout: aiohttp.ClientTimeout,
-                 separate_room_devices: bool = False):
+                 separate_room_devices: bool):
         """Initialize."""
         self._hass = hass
         self._wunda_ip = wunda_ip

--- a/custom_components/wundasmart/climate.py
+++ b/custom_components/wundasmart/climate.py
@@ -124,10 +124,14 @@ class Device(CoordinatorEntity[WundasmartDataUpdateCoordinator], ClimateEntity):
         self._wunda_user = wunda_user
         self._wunda_pass = wunda_pass
         self._wunda_id = wunda_id
-        self._attr_name = "Climate"  # Simple name since it's under the room device
+        self._attr_device_info = coordinator.get_room_device_info(wunda_id, device)
+        # Use simple name for separate devices, full name for legacy mode
+        if coordinator._separate_room_devices:
+            self._attr_name = "Climate"
+        else:
+            self._attr_name = device["name"]
         self._attr_unique_id = device["id"]
         self._attr_type = device["device_type"]
-        self._attr_device_info = coordinator.get_room_device_info(wunda_id, device)
         # This flag needs to be set until 2025.1 to prevent warnings about
         # implicitly supporting the turn_off/turn_on methods.
         # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/

--- a/custom_components/wundasmart/climate.py
+++ b/custom_components/wundasmart/climate.py
@@ -125,11 +125,8 @@ class Device(CoordinatorEntity[WundasmartDataUpdateCoordinator], ClimateEntity):
         self._wunda_pass = wunda_pass
         self._wunda_id = wunda_id
         self._attr_device_info = coordinator.get_room_device_info(wunda_id, device)
-        # Use simple name for separate devices, full name for legacy mode
-        if coordinator._separate_room_devices:
-            self._attr_name = "Climate"
-        else:
-            self._attr_name = device["name"]
+        # Use simple name for separate devices, full name otherwise
+        self._attr_name = "Climate" if coordinator._separate_room_devices else device["name"]
         self._attr_unique_id = device["id"]
         self._attr_type = device["device_type"]
         # This flag needs to be set until 2025.1 to prevent warnings about

--- a/custom_components/wundasmart/config_flow.py
+++ b/custom_components/wundasmart/config_flow.py
@@ -161,7 +161,12 @@ class OptionsFlow(config_entries.OptionsFlow):
                 CONF_PING_INTERVAL,
                 default=self.config_entry.options.get(
                     CONF_PING_INTERVAL, DEFAULT_PING_INTERVAL
-                )): int
+                )): int,
+            vol.Optional(
+                CONF_SEPARATE_ROOM_DEVICES,
+                default=self.config_entry.options.get(
+                    CONF_SEPARATE_ROOM_DEVICES, DEFAULT_SEPARATE_ROOM_DEVICES
+                )): bool
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/custom_components/wundasmart/config_flow.py
+++ b/custom_components/wundasmart/config_flow.py
@@ -61,7 +61,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
-        return OptionsFlow(config_entry)
+        return OptionsFlow()
 
     async def async_step_user(self, user_input=None):
         """Show the setup form to the user."""
@@ -133,9 +133,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class OptionsFlow(config_entries.OptionsFlow):
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         if user_input is not None:

--- a/custom_components/wundasmart/const.py
+++ b/custom_components/wundasmart/const.py
@@ -10,11 +10,13 @@ DOMAIN = "wundasmart"
 CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_READ_TIMEOUT = "read_timeout"
 CONF_PING_INTERVAL = "ping_interval"
+CONF_SEPARATE_ROOM_DEVICES = "separate_room_devices"
 
 DEFAULT_SCAN_INTERVAL = 300
 DEFAULT_CONNECT_TIMEOUT = 5
 DEFAULT_READ_TIMEOUT = 5
 DEFAULT_PING_INTERVAL = 180
+DEFAULT_SEPARATE_ROOM_DEVICES = False
 
 @dataclass
 class DeviceIdRanges:

--- a/custom_components/wundasmart/sensor.py
+++ b/custom_components/wundasmart/sensor.py
@@ -208,7 +208,7 @@ def _trv_get_room(coordinator: WundasmartDataUpdateCoordinator, device):
         return coordinator.data.get(room_id)
 
 
-def _trv_get_sensor_name(room, trv, desc: WundaSensorDescription, separate_room_devices: bool = False):
+def _trv_get_sensor_name(room, trv, desc: WundaSensorDescription, separate_room_devices: bool):
     """Return a human readable name for a TRV device"""
     device_id = int(trv["device_id"])
     hw_version = float(trv["hw_version"])
@@ -267,7 +267,7 @@ async def async_setup_entry(
                desc.name if coordinator._separate_room_devices else room["name"] + " " + desc.name,
                coordinator,
                desc,
-               room_id=wunda_id)
+               room_id=get_room_id_from_device(device))
                 for wunda_id, device, room in devices_by_type["ROOM"]
                 for desc in descriptions_by_type["ROOM"]
         ),
@@ -307,7 +307,7 @@ class Sensor(CoordinatorEntity[WundasmartDataUpdateCoordinator], SensorEntity):
         name: str,
         coordinator: WundasmartDataUpdateCoordinator,
         description: WundaSensorDescription,
-        room_id: str = None,
+        room_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -318,12 +318,8 @@ class Sensor(CoordinatorEntity[WundasmartDataUpdateCoordinator], SensorEntity):
         if (device_sn := coordinator.device_sn) is not None:
             self._attr_unique_id = f"{device_sn}.{wunda_id}.{description.key}"
         
-        # Determine device info based on whether this sensor belongs to a room
-        if room_id is not None:
-            room_device = coordinator.data.get(room_id, {})
-            self._attr_device_info = coordinator.get_room_device_info(room_id, room_device)
-        else:
-            self._attr_device_info = coordinator.device_info
+        room_device = coordinator.data.get(room_id, {})
+        self._attr_device_info = coordinator.get_room_device_info(room_id, room_device)
 
         self.entity_description = self.__update_description_defaults(description)
 

--- a/custom_components/wundasmart/strings.json
+++ b/custom_components/wundasmart/strings.json
@@ -27,7 +27,11 @@
           "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
           "connect_timeout": "Connect Timeout",
           "read_timeout": "Read Timeout",
-          "ping_interval": "Heartbeat Interval"
+          "ping_interval": "Heartbeat Interval",
+          "separate_room_devices": "Separate Room Devices"
+        },
+        "data_description": {
+          "separate_room_devices": "When enabled, each room becomes a separate device. When disabled, all entities are grouped under the hub device (legacy mode). WARNING: Switching from enabled to disabled may leave orphaned room devices that need to be manually removed from Settings > Devices & Services > Devices."
         },
         "title": "Wundasmart options"
       }

--- a/custom_components/wundasmart/strings.json
+++ b/custom_components/wundasmart/strings.json
@@ -31,7 +31,7 @@
           "separate_room_devices": "Separate Room Devices"
         },
         "data_description": {
-          "separate_room_devices": "When enabled, each room becomes a separate device. When disabled, all entities are grouped under the hub device (legacy mode). WARNING: Switching from enabled to disabled may leave orphaned room devices that need to be manually removed from Settings > Devices & Services > Devices."
+          "separate_room_devices": "When enabled, separate devices are created for each room. By default, all entities are grouped under a single device."
         },
         "title": "Wundasmart options"
       }

--- a/custom_components/wundasmart/translations/en.json
+++ b/custom_components/wundasmart/translations/en.json
@@ -27,7 +27,11 @@
               "scan_interval": "Poll Interval",
               "connect_timeout": "Connect Timeout",
               "read_timeout": "Read Timeout",
-              "ping_interval": "Heartbeat Interval"
+              "ping_interval": "Heartbeat Interval",
+              "separate_room_devices": "Separate Room Devices"
+            },
+            "data_description": {
+              "separate_room_devices": "When enabled, each room becomes a separate device. When disabled, all entities are grouped under the hub device (legacy mode). WARNING: Switching from enabled to disabled may leave orphaned room devices that need to be manually removed from Settings > Devices & Services > Devices."
             },
             "title": "Wundasmart options"
           }

--- a/custom_components/wundasmart/translations/en.json
+++ b/custom_components/wundasmart/translations/en.json
@@ -31,7 +31,7 @@
               "separate_room_devices": "Separate Room Devices"
             },
             "data_description": {
-              "separate_room_devices": "When enabled, each room becomes a separate device. When disabled, all entities are grouped under the hub device (legacy mode). WARNING: Switching from enabled to disabled may leave orphaned room devices that need to be manually removed from Settings > Devices & Services > Devices."
+              "separate_room_devices": "When enabled, separate devices are created for each room. By default, all entities are grouped under a single device."
             },
             "title": "Wundasmart options"
           }


### PR DESCRIPTION
I'm not sure if this is something you'd want, but I made a change such that instead of a single hub device with all entities beneath it there are now individual devices for each room, with the relevant entities beneath them. It reuses all the entity ids, so its a pretty seamless switch. The hub device remains in place for things like Hot Water and the heartbeat. I also added an options flow in the config to switch between the two modes on-the-fly called "Separate Rooms". If you switch from separate rooms to no rooms, it should auto clean up any orphaned devices.

I also added a preset_mode of NONE which has resolved the issue I was getting when manually changing the temperatures.

I've not encountered any issues with it in my testing.