### PR TITLE
Add PRESET_NONE to supported preset modes

### DIFF
--- a/custom_components/wundasmart/climate.py
+++ b/custom_components/wundasmart/climate.py
@@ -12,7 +12,8 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
     PRESET_ECO,
-    PRESET_COMFORT
+    PRESET_COMFORT,
+    PRESET_NONE
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -43,6 +44,7 @@ SUPPORTED_HVAC_MODES = [
 PRESET_REDUCED = "reduced"
 
 SUPPORTED_PRESET_MODES = [
+    PRESET_NONE,
     PRESET_REDUCED,
     PRESET_ECO,
     PRESET_COMFORT
@@ -140,7 +142,7 @@ class Device(CoordinatorEntity[WundasmartDataUpdateCoordinator], ClimateEntity):
         self._attr_target_temperature = None
         self._attr_current_humidity = None
         self._attr_hvac_mode = HVACMode.AUTO
-        self._attr_preset_mode = None
+        self._attr_preset_mode =  PRESET_NONE
         self._timeout = timeout
 
         # Update with initial state
@@ -227,7 +229,7 @@ class Device(CoordinatorEntity[WundasmartDataUpdateCoordinator], ClimateEntity):
                 except (ValueError, TypeError):
                     _LOGGER.warning(f"Unexpected {state_key} value '{state[state_key]}' for {self._attr_name}")
         else:
-            self._attr_preset_mode = None
+            self._attr_preset_mode =  PRESET_NONE
 
     def __set_hvac_state(self):
         """Set the hvac action and hvac mode from the coordinator data."""
@@ -373,7 +375,7 @@ class Device(CoordinatorEntity[WundasmartDataUpdateCoordinator], ClimateEntity):
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode) -> None:
-        if preset_mode:
+        if preset_mode and preset_mode != PRESET_NONE:
             state_key = PRESET_MODE_STATE_KEYS.get(preset_mode)
             if state_key is None:
                 raise NotImplementedError(f"Unsupported Preset mode {preset_mode}")


### PR DESCRIPTION
Splits the preset none fix from the separation of rooms, as requested.